### PR TITLE
Fix deploy workflow env var file creation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,11 +44,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           gcloud config set project "${PROJECT_ID}"
-          REPO_MAP_ESCAPED="${REPO_MAP//,/\\,}"
+          printf '%s\n' \
+            "REGION=${REGION}" \
+            "CLOUD_RUN_SERVICES=${SERVICES}" \
+            "REPO_MAP_JSON=${REPO_MAP}" \
+            "CODEX_HANDLE=${CODEX_HANDLE}" \
+            "WINDOW_MIN=${WINDOW_MIN}" \
+            "MAX_LINES=${MAX_LINES}" \
+            "MAX_CHARS=${MAX_CHARS}" \
+            "WEBHOOK_USER=${BASIC_USER}" \
+            "WEBHOOK_PASS=${BASIC_PASS}" \
+            "GITHUB_TOKEN=${GH_TOKEN}" \
+            > env-vars.txt
           gcloud run deploy "$SERVICE_NAME" \
             --project "${PROJECT_ID}" \
             --region "${REGION}" \
             --source . \
             --allow-unauthenticated \
-            --set-env-vars REGION="${REGION}",CLOUD_RUN_SERVICES="${SERVICES}",REPO_MAP_JSON="${REPO_MAP_ESCAPED}",CODEX_HANDLE="${CODEX_HANDLE}",WINDOW_MIN="${WINDOW_MIN}",MAX_LINES="${MAX_LINES}",MAX_CHARS="${MAX_CHARS}",WEBHOOK_USER="${BASIC_USER}",WEBHOOK_PASS="${BASIC_PASS}",GITHUB_TOKEN="${GH_TOKEN}" \
+            --env-vars-file env-vars.txt \
             --quiet
+          rm env-vars.txt


### PR DESCRIPTION
## Summary
- update the deploy workflow to write the Cloud Run environment file with printf so the YAML indentation stays valid

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1b9dab8f0832d87da82bdf75c8b1f